### PR TITLE
FIX: Remove tensorflow since no longer supported on Windows.

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -12,9 +12,7 @@ dependencies:
   - matplotlib
   - pydda
   - jaxopt
-  - tensorflow>=2.6
   - xradar
-  - tensorflow-probability>=0.24
   - tobac
   - scikit-learn
   - pytorch


### PR DESCRIPTION
Removing tensorflow from the summer school environment since it is both not needed and no longer supported on Windows.